### PR TITLE
Allow running simulation from the command line

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
                             <addClasspath>true</addClasspath>
                             <!-- Specifies that all dependencies of our application are found -->
                             <!-- Configures the main class of the application -->
-			    <mainClass>com.ruthelde.Main.MainWindow</mainClass>
+                            <mainClass>com.ruthelde.Main.MainWindow</mainClass>
                         </manifest>
                     </archive>
                 </configuration>

--- a/src/main/java/com/ruthelde/Main/MainWindow.java
+++ b/src/main/java/com/ruthelde/Main/MainWindow.java
@@ -31,8 +31,6 @@ import java.util.*;
 
 import static com.ruthelde.DataFileReader.FileType.*;
 
-
-
 public class MainWindow extends JFrame implements Observer {
 
     private final String TARGET_NOTIFICATION = "TargetModel";
@@ -136,16 +134,19 @@ public class MainWindow extends JFrame implements Observer {
         spectrumSimulator.setTarget(targetModel.getTarget()); //Just to have an initial plot drawn
         uncertaintyEngine = new UncertaintyEngine();
 
-        if (args.length == 0) {return; }
+        if (args.length == 0) {
+            System.out.println("Usage: java -jar IBA.jar {help|run_de|simulate} [...]");
+            return;
+        }
 
         if (args[0].equals("help")) {
             System.out.println("Usage: java -jar IBA.jar {help|run_de|simulate} [...]");
             System.out.println("help ");
             System.out.println("run_de   [input] [fileType] [spectrum_1 ... spectrum_N]  runs differential evolution");
             System.out.println("         [input] (absolute) path to IBA simulation file which is used to extract");
-            System.out.println("                 input parameters like target model and  experimental constrains from.");
+            System.out.println("                 input parameters like target model and experimental constrains from.");
             System.out.println("         [fileType] specifies the tye of following iba spectra. Allowed values:");
-            System.out.println("                    IBC_RBS, IBC_3MV_SINGLE, IBC_3MV_MULTI, IMEC, IBA_SIM");
+            System.out.println("                    ASCII_ONE, ASCII_TWO, IBC_RBS, IBC_3MV_SINGLE, IBC_3MV_MULTI, IMEC, IBA_SIM");
             System.out.println("         [spectrum_1 ... spectrum_N] (absolute) file paths to spectra files");
             System.out.println("simulate [input-file] [output-file] Generate data from simulation");
             System.exit(0);
@@ -161,7 +162,7 @@ public class MainWindow extends JFrame implements Observer {
             System.exit(0);
         }
 
-        if(args[0].equals("run_de")) {
+        if (args[0].equals("run_de")) {
             System.out.println("Importing parameters from simulation file.");
             loadSimulation(args[1]);
 
@@ -204,7 +205,6 @@ public class MainWindow extends JFrame implements Observer {
                     doBatchGASimulation(files, fileType);
                 }
             }
-<<<<<<< HEAD
         } else {
 
             if (args.length == 1 && args[0].equals("help")) {
@@ -223,8 +223,6 @@ public class MainWindow extends JFrame implements Observer {
 
                 System.exit(0);
             }
-=======
->>>>>>> a28bfcf (added simulation as command line feature)
         }
     }
 

--- a/src/main/java/com/ruthelde/Main/MainWindow.java
+++ b/src/main/java/com/ruthelde/Main/MainWindow.java
@@ -31,6 +31,8 @@ import java.util.*;
 
 import static com.ruthelde.DataFileReader.FileType.*;
 
+
+
 public class MainWindow extends JFrame implements Observer {
 
     private final String TARGET_NOTIFICATION = "TargetModel";
@@ -134,10 +136,34 @@ public class MainWindow extends JFrame implements Observer {
         spectrumSimulator.setTarget(targetModel.getTarget()); //Just to have an initial plot drawn
         uncertaintyEngine = new UncertaintyEngine();
 
-        if (args.length >= 3) {
+        if (args.length == 0) {return; }
 
+        if (args[0].equals("help")) {
+            System.out.println("Usage: java -jar IBA.jar {help|run_de|simulate} [...]");
+            System.out.println("help ");
+            System.out.println("run_de [input] [fileType] [spectrum_1 ... spectrum_N]  runs differential evolution");
+            System.out.println("    [input]     (absolute) path to IBA simulation file which is used to extract");
+            System.out.println("                input parameters like target model and  experimental constrains from.");
+            System.out.println("    [fileType] specifies the tye of following iba spectra. Allowed values:");
+            System.out.println("               IBC_RBS, IBC_3MV_SINGLE, IBC_3MV_MULTI, IMEC, IBA_SIM");
+            System.out.println("    [spectrum_1 ... spectrum_N] (absolute) file paths to spectra files");
+            System.out.println("simulate [input-file] [output-file] Generate data from simulation");
+            System.exit(0);
+        }
+
+        if (args[0].equals("simulate")) {
+            System.out.println("Running simulation");
+            loadSimulation(args[1]);
+            spectraPlotWindow.setVisible(true);
+            spectraPlotWindow.setSize(800, 500);
+            File f = new File(args[2]);
+            spectraPlotWindow.exportAscii(f);
+            System.exit(0);
+        }
+
+        if(args[0].equals("run_de")) {
             System.out.println("Importing parameters from simulation file.");
-            loadSimulation(args[0]);
+            loadSimulation(args[1]);
 
             FileType fileType = null;
             if (args[1].equals("ASCII_ONE")) fileType = ONE_COLUMN_ASCII;
@@ -151,11 +177,11 @@ public class MainWindow extends JFrame implements Observer {
             if (fileType != null) {
                 System.out.println("Parsed file type to be *" + fileType.toString() + "*");
 
-                File files[] = new File[args.length - 2];
+                File files[] = new File[args.length - 3];
                 boolean error = false;
 
-                for (int i = 0; i < (args.length - 2); i++) {
-                    files[i] = new File(args[i + 2]);
+                for (int i = 0; i < (args.length - 3); i++) {
+                    files[i] = new File(args[i + 3]);
                     if (files[i] == null) {
                         error = true;
                         break;
@@ -178,6 +204,7 @@ public class MainWindow extends JFrame implements Observer {
                     doBatchGASimulation(files, fileType);
                 }
             }
+<<<<<<< HEAD
         } else {
 
             if (args.length == 1 && args[0].equals("help")) {
@@ -196,6 +223,8 @@ public class MainWindow extends JFrame implements Observer {
 
                 System.exit(0);
             }
+=======
+>>>>>>> a28bfcf (added simulation as command line feature)
         }
     }
 

--- a/src/main/java/com/ruthelde/Main/MainWindow.java
+++ b/src/main/java/com/ruthelde/Main/MainWindow.java
@@ -141,12 +141,12 @@ public class MainWindow extends JFrame implements Observer {
         if (args[0].equals("help")) {
             System.out.println("Usage: java -jar IBA.jar {help|run_de|simulate} [...]");
             System.out.println("help ");
-            System.out.println("run_de [input] [fileType] [spectrum_1 ... spectrum_N]  runs differential evolution");
-            System.out.println("    [input]     (absolute) path to IBA simulation file which is used to extract");
-            System.out.println("                input parameters like target model and  experimental constrains from.");
-            System.out.println("    [fileType] specifies the tye of following iba spectra. Allowed values:");
-            System.out.println("               IBC_RBS, IBC_3MV_SINGLE, IBC_3MV_MULTI, IMEC, IBA_SIM");
-            System.out.println("    [spectrum_1 ... spectrum_N] (absolute) file paths to spectra files");
+            System.out.println("run_de   [input] [fileType] [spectrum_1 ... spectrum_N]  runs differential evolution");
+            System.out.println("         [input] (absolute) path to IBA simulation file which is used to extract");
+            System.out.println("                 input parameters like target model and  experimental constrains from.");
+            System.out.println("         [fileType] specifies the tye of following iba spectra. Allowed values:");
+            System.out.println("                    IBC_RBS, IBC_3MV_SINGLE, IBC_3MV_MULTI, IMEC, IBA_SIM");
+            System.out.println("         [spectrum_1 ... spectrum_N] (absolute) file paths to spectra files");
             System.out.println("simulate [input-file] [output-file] Generate data from simulation");
             System.exit(0);
         }


### PR DESCRIPTION
For our scripting we would like to be able to use the simulation option from the command line. This pull request implements this behavior. Be aware that this changes the required command line arguments.

Since before, it would always perform the differential evolution, an extra command line argument had to be added. You now have to specify one of the following:

- help
- run_de
- simulate

If you have suggestions to do this a different way please let me know.